### PR TITLE
[어드민] 게시글 관리 페이지 만들기

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/controller/MainController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/MainController.java
@@ -1,7 +1,9 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 
 @Controller
 public class MainController {
@@ -9,6 +11,27 @@ public class MainController {
     @GetMapping("/")
     public String root() {
         return "forward:/management/articles";
+    }
+
+    @ModelAttribute("requestURI")
+    public String requestURI(final HttpServletRequest request) {
+        return request.getRequestURI();
+    }
+
+    @ModelAttribute("startsWithManagement")
+    public String startsWithManagement(final HttpServletRequest request) {
+        if(request.getRequestURI().startsWith("/management")){
+            return  "/management";
+        };
+        return "";
+    }
+
+    @ModelAttribute("startsWithAdmin")
+    public String startsWithAdmin(final HttpServletRequest request) {
+        if(request.getRequestURI().startsWith("/admin")){
+            return  "/admin";
+        };
+        return "";
     }
 
 }

--- a/src/main/resources/templates/layouts/layout-left-aside.th.xml
+++ b/src/main/resources/templates/layouts/layout-left-aside.th.xml
@@ -2,26 +2,26 @@
 <thlogic>
   <attr sel="#admin-logo-link" th:href="@{/}" />
   <attr sel="#user-profile" th:href="@{#}" />
-  <attr sel="#management-category" th:classappend="${#request.requestURI.startsWith('/management')} ? 'active'" />
+  <attr sel="#management-category" th:classappend="${startsWithManagement == '/management'} ? 'active'" />
   <attr
       sel="#article-management"
       th:href="@{/management/articles}"
-      th:classappend="${#request.requestURI.equals('/management/articles')} ? 'active'"
+      th:classappend="${requestURI == '/management/articles'} ? 'active'"
   />
   <attr
       sel="#article-comment-management"
       th:href="@{/management/article-comments}"
-      th:classappend="${#request.requestURI.equals('/management/article-comments')} ? 'active'"
+      th:classappend="${requestURI == '/management/article-comments'} ? 'active'"
   />
   <attr
       sel="#user-account-management"
       th:href="@{/management/user-accounts}"
-      th:classappend="${#request.requestURI.equals('/management/user-accounts')} ? 'active'"
+      th:classappend="${requestURI == '/management/user-accounts'} ? 'active'"
   />
-  <attr sel="#admin-category" th:classappend="${#request.requestURI.startsWith('/admin')} ? 'active'" />
+  <attr sel="#admin-category" th:classappend="${startsWithAdmin == '/admin'} ? 'active'" />
   <attr
       sel="#admin-members"
       th:href="@{/admin/members}"
-      th:classappend="${#request.requestURI.equals('/admin/members')} ? 'active'"
+      th:classappend="${requestURI == '/admin/members'} ? 'active'"
   />
 </thlogic>

--- a/src/main/resources/templates/management/articles.html
+++ b/src/main/resources/templates/management/articles.html
@@ -1,10 +1,89 @@
 <!DOCTYPE html>
 <html lang="ko">
-<head>
+<head id="layout-head">
     <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
+    <title>게시글 관리 페이지</title>
 
+    <link rel="stylesheet" href="/js/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
+    <link rel="stylesheet" href="/js/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+    <link rel="stylesheet" href="/js/plugins/datatables-buttons/css/buttons.bootstrap4.min.css">
+</head>
+<body class="hold-transition sidebar-mini">
+<div class="wrapper">
+    <header id="layout-header">헤더 삽입부</header>
+    <aside id="layout-left-aside">왼쪽 사이드 바 삽입부</aside>
+
+    <!-- Main content -->
+    <main id="layout-main">
+        <table id="main-table" class="table table-bordered table-striped">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>제목</th>
+                <th>작성자</th>
+                <th>작성일시</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>1</td>
+                <td>새 글</td>
+                <td>Uno</td>
+                <td><time datetime="2022-01-01T00:00:00">2022-01-01 00:00:00</time></td>
+            </tr>
+            <tr>
+                <td>2</td>
+                <td>아무글</td>
+                <td>Uno</td>
+                <td><time datetime="2022-01-02T00:00:00">2022-01-02 00:00:00</time></td>
+            </tr>
+            <tr>
+                <td>3</td>
+                <td>스프링 부트 블로그 정리</td>
+                <td>Uno</td>
+                <td><time datetime="2022-01-03T00:00:00">2022-01-03 00:00:00</time></td>
+            </tr>
+            </tbody>
+            <tfoot>
+            <tr>
+                <th>ID</th>
+                <th>제목</th>
+                <th>작성자</th>
+                <th>작성일시</th>
+            </tr>
+            </tfoot>
+        </table>
+    </main>
+    <!-- /.content -->
+
+    <aside id="layout-right-aside">오른쪽 사이드 바 삽입부</aside>
+    <footer id="layout-footer">푸터 삽입부</footer>
+</div>
+
+<!--/* REQUIRED SCRIPTS */-->
+<script id="layout-scripts">/* 공통 스크립트 삽입부 */</script>
+
+<!--/* 페이지 전용 스크립트 */-->
+<script src="/js/plugins/datatables/jquery.dataTables.min.js"></script>
+<script src="/js/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
+<script src="/js/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
+<script src="/js/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+<script src="/js/plugins/datatables-buttons/js/dataTables.buttons.min.js"></script>
+<script src="/js/plugins/datatables-buttons/js/buttons.bootstrap4.min.js"></script>
+<script src="/js/plugins/jszip/jszip.min.js"></script>
+<script src="/js/plugins/pdfmake/pdfmake.min.js"></script>
+<script src="/js/plugins/pdfmake/vfs_fonts.js"></script>
+<script src="/js/plugins/datatables-buttons/js/buttons.html5.min.js"></script>
+<script src="/js/plugins/datatables-buttons/js/buttons.print.min.js"></script>
+<script src="/js/plugins/datatables-buttons/js/buttons.colVis.min.js"></script>
+<script>
+    $(function () {
+        $("#main-table").DataTable({
+            "responsive": true, "lengthChange": false, "autoWidth": false,
+            "buttons": ["copy", "csv", "excel", "pdf", "print", "colvis"],
+            "pageLength": 10
+        }).buttons().container().appendTo('#main-table_wrapper .col-md-6:eq(0)'); // main-table_wrapper ID는 플러그인에 의해 자동 생성됨
+    });
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/management/articles.th.xml
+++ b/src/main/resources/templates/management/articles.th.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
+    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
+    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
+    <attr sel="#layout-main" th:replace="layouts/layout-main-table :: common_main_table('게시글 관리', (~{::#main-table} ?: ~{}))" />
+    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
+    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
+    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+</thlogic>


### PR DESCRIPTION
이 pr은 게시글 관리 페이지에 공통 레이아웃을 이용해 디자인을 입히고, 
데이터 테이블을 자바스크립트 플러그인을 사용해 그려낸다.

또한, thymeleaf 3.1 및 Spring Security 6.0. 관련 이슈사항도 리팩토링 하였다.

#request 같은 경우, thymeleaf 3.1 부터는 더이상 지원하지 않으므로,
컨트롤러단에서  별도로 ModelAttribute를 추가해줘야 한다.

`requestURI`, `startWithManagement`, `startsWithAdmin` 등
layout-left-aside.th.xml에 쓰인 thymeleaf 문법을 ModelAttribute로 전환하여
적용하니, 정상적으로 작동한다.

* https://www.thymeleaf.org/doc/articles/thymeleaf31whatsnew.html
* https://www.thymeleaf.org/doc/tutorials/3.1/usingthymeleaf.html
* https://stackoverflow.com/questions/74594544/getrequesturi-is-null-with-netty-and-spring-boot-3


This closes #10 